### PR TITLE
Jc prototype

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,5 +86,5 @@ The Initiators
 ==============
 
 We are people interested using markdown and `pandoc` to write manuscripts, and include contributor lists in research outputs (datasets, software, artilces).
-We work on different projects like [GIN](gin.g-node.org), [`pandoc-scholar`](https://github.com/pandoc-scholar/pandoc-scholar), the [`tenzing`](https://github.com/marton-balazs-kovacs/tenzing) and [`papaja`](https://github.com/crsh/papaja).
+We work on different projects like [GIN](https://gin.g-node.org), [`pandoc-scholar`](https://github.com/pandoc-scholar/pandoc-scholar), the [`tenzing`](https://github.com/marton-balazs-kovacs/tenzing) and [`papaja`](https://github.com/crsh/papaja).
 

--- a/prototype1/prototype_v1_JC_example.yml
+++ b/prototype1/prototype_v1_JC_example.yml
@@ -10,14 +10,14 @@ author:
     role:
       Conceptualization: created first prototype
     affiliation:
-      ref1
+      aff_01
     part-of-group: NA   
     attributes:
       is.corresponding.author: yes
       type: author
     
 Affiliation:
-  - refid: ref1
+  - refid: aff_01
     name: Humboldt-Universität zu Berlin, SFB1315, Inst. of Biology, Charitéplatz 1,  10117 Berlin
     PID:
       type: RINGGOLD

--- a/prototype1/prototype_v1_JC_example.yml
+++ b/prototype1/prototype_v1_JC_example.yml
@@ -1,0 +1,28 @@
+author:
+  - string-name:
+  - surname: Colomb
+  - given-names: Julien
+  - email: julien.colomb@fu-berlin.de
+  - PID:
+    - type: orcid-id
+    - id: https://orcid.org/0000-0002-3127-5520
+  - role:
+    - Conceptualization: created first prototype
+  - affiliation:
+    - ref1
+  - part-of-group: NA   
+  - attributes:
+    - is.corresponding.author: yes
+    - type: author
+    
+Affiliation:
+  - refid: ref1
+  - name: Humboldt-Universität zu Berlin, SFB1315, Inst. of Biology, Charitéplatz 1,  10117 Berlin
+  - PID:
+    - type: RINGGOLD
+    - id: 9373
+  - city: Berlin
+  - region: Berlin
+  - postal.code: 10117
+  - country.code: DE
+  - country: Germany

--- a/prototype1/prototype_v1_JC_example.yml
+++ b/prototype1/prototype_v1_JC_example.yml
@@ -17,8 +17,7 @@ author:
       type: author
     
 Affiliation:
-  -
-    refid: ref1
+  - refid: ref1
     name: Humboldt-Universität zu Berlin, SFB1315, Inst. of Biology, Charitéplatz 1,  10117 Berlin
     PID:
       type: RINGGOLD

--- a/prototype1/prototype_v1_JC_example.yml
+++ b/prototype1/prototype_v1_JC_example.yml
@@ -1,28 +1,30 @@
 author:
-  - string-name:
-  - surname: Colomb
-  - given-names: Julien
-  - email: julien.colomb@fu-berlin.de
-  - PID:
-    - type: orcid-id
-    - id: https://orcid.org/0000-0002-3127-5520
-  - role:
-    - Conceptualization: created first prototype
-  - affiliation:
-    - ref1
-  - part-of-group: NA   
-  - attributes:
-    - is.corresponding.author: yes
-    - type: author
+  -
+    string-name:
+    surname: Colomb
+    given-names: Julien
+    email: julien.colomb@fu-berlin.de
+    PID:
+      type: orcid-id
+      id: https://orcid.org/0000-0002-3127-5520
+    role:
+      Conceptualization: created first prototype
+    affiliation:
+      ref1
+    part-of-group: NA   
+    attributes:
+      is.corresponding.author: yes
+      type: author
     
 Affiliation:
-  - refid: ref1
-  - name: Humboldt-Universität zu Berlin, SFB1315, Inst. of Biology, Charitéplatz 1,  10117 Berlin
-  - PID:
-    - type: RINGGOLD
-    - id: 9373
-  - city: Berlin
-  - region: Berlin
-  - postal.code: 10117
-  - country.code: DE
-  - country: Germany
+  -
+    refid: ref1
+    name: Humboldt-Universität zu Berlin, SFB1315, Inst. of Biology, Charitéplatz 1,  10117 Berlin
+    PID:
+      type: RINGGOLD
+      id: 9373
+    city: Berlin
+    region: Berlin
+    postal.code: 10117
+    country.code: DE
+    country: Germany

--- a/prototype_v1_JC.yml
+++ b/prototype_v1_JC.yml
@@ -20,7 +20,7 @@ Affiliation:
   - name:
   - PID:
     - type:
-    - number:
+    - id:
   - city:
   - region:
   - postal.code:

--- a/prototype_v1_JC.yml
+++ b/prototype_v1_JC.yml
@@ -10,6 +10,7 @@ author:
   - affiliation:
     - ref1
     - ref2
+  - part-of-group:   
   - attributes:
     - is.corresponding.author: no
     - type: author

--- a/prototype_v1_JC.yml
+++ b/prototype_v1_JC.yml
@@ -9,7 +9,7 @@ author:
       id: 
     role:
     affiliation:
-      ref1
+      aff_01
     part-of-group: NA   
     attributes:
       is.corresponding.author: no

--- a/prototype_v1_JC.yml
+++ b/prototype_v1_JC.yml
@@ -1,28 +1,28 @@
 author:
-  - string-name:
-  - surname:
-  - given-names:
-  - email:
-  - PID:
-    - type: orcid-id
-    - id:
-  - role:
-  - affiliation:
-    - ref1
-    - ref2
-  - part-of-group:   
-  - attributes:
-    - is.corresponding.author: no
-    - type: author
+  -
+    string-name:
+    surname: 
+    given-names: 
+    email: 
+    PID:
+      type: orcid-id
+      id: 
+    role:
+    affiliation:
+      ref1
+    part-of-group: NA   
+    attributes:
+      is.corresponding.author: no
+      type: author
     
 Affiliation:
-  - refid: ref1
-  - name:
-  - PID:
-    - type:
-    - id:
-  - city:
-  - region:
-  - postal.code:
-  - country.code:
-  - country:
+  - refid: 
+    name: 
+    PID:
+      type: RINGGOLD
+      id: 
+    city: 
+    region: 
+    postal.code: 
+    country.code: 
+    country: 

--- a/prototype_v1_JC.yml
+++ b/prototype_v1_JC.yml
@@ -1,0 +1,27 @@
+author:
+  - string-name:
+  - surname:
+  - given-names:
+  - email:
+  - PID:
+    - type: orcid-id
+    - id:
+  - role:
+  - affiliation:
+    - ref1
+    - ref2
+  - attributes:
+    - is.corresponding.author: no
+    - type: author
+    
+Affiliation:
+  - refid: ref1
+  - name:
+  - PID:
+    - type:
+    - number:
+  - city:
+  - region:
+  - postal.code:
+  - country.code:
+  - country:

--- a/requirement/author_needed_infromation.md
+++ b/requirement/author_needed_infromation.md
@@ -12,32 +12,147 @@ Main sourece of information: https://jats4r.org/authors-and-affiliations, https:
 - email
 
 - affiliation (work):
+    
+    - department (free text entry)
+    - organisation name (automatic)
+    - organisation address(automatic): city, region, country code
+    - PID number (automatic)
+    - PID source (automatic) (RINGOLD)
 
-    - organisation
-    - address
-    - PID
+
+- funder information (could be used in the aknowledgement section):
+
+  - title
+  - organisation name + address
+  - PID number (automatic)
+  - PID source (automatic) (FUNDREF)
+  - grant_number
+  - grant url
+  
+- keywords (could be used as default keywords for the paper)
+
+# JATSxml
+
+Example 1 had many features explained.
+
+```{xml}
+<contrib-group>
+  <contrib-group>
+  <contrib contrib-type=”author” corresp="yes">
+    <string-name> julien colomb</string-name>
+    <contrib-id authenticated="true" contrib-id-type="orcid">https://orcid.org/0000-0002-9615-3022</contrib-id>
+    <email>ahonigm@gwdg.de</email>
+    <aff id=”aff1”>the world</aff>
+    <xref ref-type="corresp" rid="cor1">
+  </contrib>        
+    <contrib contrib-type=”author”>
+     <collab>The authors and affiliations working group 
+       <contrib-group>
+         <contrib><string-name>Prince Charles </string-name>
+         <aff id=”aff1”>Buckingham Palace, England</aff></contrib><contrib>
+         <string-name><surname>Cooke</surname><given-names>James L.</given-names></string-name>
+         <aff id=”aff2”>Royal Navy, London, UK</aff></contrib>
+        </contrib-group>
+     </collab>
+   <aff id=”aff3”>
+    <institution-wrap>
+      <institution-id institution-id-type=”ringgold”>2188</institution-id>
+      <institution>Harvard Law School</institution>
+    </institution-wrap>
+    <city>Cambridge</city>, <state>MA</state> <postal-code>02138</postal-code>, <country @country=”us”>United States of America</country>
+   </aff>
+</contrib>
+<author-notes><corresp id="cor1"><label>*</label>For correspondence: <email>ahonigm@gwdg.de</email> (AH);</corresp>
+
+</contrib-group>
+```
+
+## groups
+
+A group of people can be an author, in this case the collab tag is used.
+
+the title of the group is given by collab
+under the collab group, there may be the people tags, in this case a new <contrib-group> tag is used.
+
+NB groups can have an affiliation.
 
 
-- funder information
 
-# JTSxml
+## people
 
-## name
+### contribution type
 
-There are different ways to deal with this, pandoc will only use the name string to create tex/pdf version (ALBERT?), while Jats can, but does not must, have given name and family name entry.
-Because some people do not have a family name, there should be a way to get author name without having to enter some family name.
+This allows to have contributors who are not authors. It can also be used for authors present in a group by seeting type = "non-byline author".
+In practice, it would meant that people of type author are listed in the author list, while others would be indicated in the aknowledgement section.
 
-I would propose the format to have:
-- string-name
-- first name
-- middle name
-- family name
+For version 1, I think we can take for granted there is only the author type ?
 
-Exceptions: author can also be a group, not a person, then the collab term is used in jats, instead of string-name. Member of the group may be indicated with a specific contributor type
+### corresp + email
 
-# PID (<contrib-id>.)
+This option is set for the corresponding author, then the email should be indicated too, in the author-note section or directly (?).
+
+
+### name
+
+people are named using:
+
+string-name
+
+or
+
+surname + given-names
+
+NB: middle names are included in given-names with the initials
+
+
+## PID (<contrib-id>)
 
 - type
 - id
 
 # Affiliation
+
+- name
+- id type
+- id number
+- address
+- country
+
+<label> will be created automatically by pandoc
+<institution> name of the institution
+<institution-id>: type and id
+<institution-id institution-id-type=”ringgold”>1812</institution-id>
+
+# Summary info (jats term - orcid term)
+
+# authors
+
+## name:
+
+string-name = publication name
+
+given-names = first name
+surname = family name
+
+* either string-name or both given-names and surname should be indicated
+
+## author other attributes (maybe included via xref)
+
+PID
+affiliation
+author-notes:email or email = email
+role (credit)
+
+## contributor attributes:
+type (author, non-byline author, editor ,??)
+corresponding author (yes, no)
+
+# affiliation
+
+- name
+- PID type
+- PID number
+- city
+- region
+- country
+- postal code


### PR DESCRIPTION
I worked the requirement and added a first prototype for discussion.

For simplicity, I propose to keep affilliation outside of the author entries and refer to them, in all cases. While this makes the information about one author less portable, it will facilitates the work of pandoc (@tarleb ?).

For groups, I would propose to link people to groups via a `part.of.group` entry and use the author type to deal with it:
author type = author (normal), group (this is the name of a group of authors), non-byline-author (author belonging to a group), non-author-contributor (people normally ending in the aknowledgements)
