### PR TITLE
affiliation details, byline order integration

### DIFF
--- a/prototype_v1_JC.yml
+++ b/prototype_v1_JC.yml
@@ -18,7 +18,7 @@ author:
       is-corresponding-author: no
       type: author
       deceased: no
-      equal contribution: no
+      equal-contrib: no
       byline-position:
     
 Affiliation:

--- a/prototype_v1_JC.yml
+++ b/prototype_v1_JC.yml
@@ -8,6 +8,8 @@ author:
       type: orcid-id
       id: 
     role:
+      vocab-term-identifier: free text explanation
+      vocab-term-identifier: free text explanation
     affiliation:
       aff_01
     part-of-group: NA   
@@ -19,7 +21,6 @@ author:
     
 Affiliation:
   - refid: 
-
     institution:  
     PID:
       type: RINGGOLD

--- a/prototype_v1_JC.yml
+++ b/prototype_v1_JC.yml
@@ -14,13 +14,20 @@ author:
     attributes:
       is.corresponding.author: no
       type: author
+      contributed-equally: no
+      byline-position:
     
 Affiliation:
   - refid: 
-    name: 
+
+    institution:  
     PID:
       type: RINGGOLD
       id: 
+    details: 
+      group: 
+      department:  
+      street-address:  
     city: 
     region: 
     postal.code: 

--- a/prototype_v1_JC.yml
+++ b/prototype_v1_JC.yml
@@ -34,6 +34,6 @@ Affiliation:
     city: 
     region: 
     postal-code: 
-    country.code: 
+    country-code: 
     country: 
     

--- a/prototype_v1_JC.yml
+++ b/prototype_v1_JC.yml
@@ -36,3 +36,4 @@ Affiliation:
     postal-code: 
     country.code: 
     country: 
+    

--- a/prototype_v1_JC.yml
+++ b/prototype_v1_JC.yml
@@ -14,7 +14,7 @@ author:
       aff_01
     part-of-group: NA   
     attributes:
-      is.corresponding.author: no
+      is-corresponding-author: no
       type: author
       contributed-equally: no
       byline-position:
@@ -31,6 +31,6 @@ Affiliation:
       street-address:  
     city: 
     region: 
-    postal.code: 
+    postal-code: 
     country.code: 
     country: 

--- a/prototype_v1_JC.yml
+++ b/prototype_v1_JC.yml
@@ -3,7 +3,8 @@ author:
     string-name:
     surname: 
     given-names: 
-    email: 
+    email:
+    phone:
     PID:
       type: orcid-id
       id: 
@@ -16,7 +17,8 @@ author:
     attributes:
       is-corresponding-author: no
       type: author
-      contributed-equally: no
+      deceased: no
+      equal contribution: no
       byline-position:
     
 Affiliation:


### PR DESCRIPTION
Affiliation: 
only institution have a PID, <institution> is normally associated witht the organisation name, department and addresses are indicated without specific tags:
``` 
<aff id="aff3"><label>3</label>Dalla Lana School of Public Health, <institution>University of Toronto</institution>, <addr-line><city>Toronto</city>, <state>ON</state></addr-line>, <country>Canada</country></aff>
```